### PR TITLE
Fix CEEMDAN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 dist
 *.swp
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
 dist
 *.swp
-.vscode/settings.json

--- a/PyEMD/CEEMDAN.py
+++ b/PyEMD/CEEMDAN.py
@@ -169,7 +169,7 @@ class CEEMDAN:
     def ceemdan(self, S, T=None, max_imf=-1):
 
         scale_s = np.std(S)
-        S = S/scale_s
+        S[:] = S/scale_s
 
         # Define all noise
         self.all_noises = self.generate_noise(1, (self.trials,S.size))
@@ -312,6 +312,7 @@ class CEEMDAN:
 if __name__ == "__main__":
 
     import pylab as plt
+    import copy
 
     # Logging options
     logging.basicConfig(level=logging.INFO)
@@ -324,12 +325,13 @@ if __name__ == "__main__":
     T = np.linspace(tMin, tMax, N)
 
     S = 3*np.sin(4*T) + 4*np.cos(9*T) + np.sin(8.11*T+1.2)
+    Scopy = copy.copy(S)
 
     # Prepare and run EEMD
     trials = 20
     ceemdan = CEEMDAN(trials=trials)
 
-    C_IMFs = ceemdan(S, T, max_imf)
+    C_IMFs = ceemdan(Scopy, T, max_imf)
     imfNo  = C_IMFs.shape[0]
 
     # Plot results in a grid

--- a/PyEMD/CEEMDAN.py
+++ b/PyEMD/CEEMDAN.py
@@ -169,7 +169,7 @@ class CEEMDAN:
     def ceemdan(self, S, T=None, max_imf=-1):
 
         scale_s = np.std(S)
-        S[:] = S/scale_s
+        S = S/scale_s
 
         # Define all noise
         self.all_noises = self.generate_noise(1, (self.trials,S.size))
@@ -312,7 +312,6 @@ class CEEMDAN:
 if __name__ == "__main__":
 
     import pylab as plt
-    import copy
 
     # Logging options
     logging.basicConfig(level=logging.INFO)
@@ -325,13 +324,12 @@ if __name__ == "__main__":
     T = np.linspace(tMin, tMax, N)
 
     S = 3*np.sin(4*T) + 4*np.cos(9*T) + np.sin(8.11*T+1.2)
-    Scopy = copy.copy(S)
 
     # Prepare and run EEMD
     trials = 20
     ceemdan = CEEMDAN(trials=trials)
 
-    C_IMFs = ceemdan(Scopy, T, max_imf)
+    C_IMFs = ceemdan(S, T, max_imf)
     imfNo  = C_IMFs.shape[0]
 
     # Plot results in a grid

--- a/PyEMD/CEEMDAN.py
+++ b/PyEMD/CEEMDAN.py
@@ -312,6 +312,7 @@ class CEEMDAN:
 if __name__ == "__main__":
 
     import pylab as plt
+    import copy
 
     # Logging options
     logging.basicConfig(level=logging.INFO)
@@ -324,12 +325,13 @@ if __name__ == "__main__":
     T = np.linspace(tMin, tMax, N)
 
     S = 3*np.sin(4*T) + 4*np.cos(9*T) + np.sin(8.11*T+1.2)
+    Scopy = copy.copy(S)
 
     # Prepare and run EEMD
     trials = 20
     ceemdan = CEEMDAN(trials=trials)
 
-    C_IMFs = ceemdan(S, T, max_imf)
+    C_IMFs = ceemdan(Scopy, T, max_imf)
     imfNo  = C_IMFs.shape[0]
 
     # Plot results in a grid


### PR DESCRIPTION
My python version is `3.6.4`. I have tested EMD, EEMD and CEEMDAN to decomposite a piece of music,  and I found the plotted `Original signal` is wrong if I use CEEMDAN as you can see in Fig.3, compared with Figs.1-2. The same issue is opened in #42 . In #42 and #44 one can find he will receive a wrong result if he uses `res = S-np.sum(C_IMFs, axis=0)` to calculate the residual due to the wrong `Original signal`.
![music_emd.png](https://i.loli.net/2019/03/17/5c8e422d8bea5.png)
Fig.1 EMD
![music_eemd.png](https://i.loli.net/2019/03/17/5c8e422dc0d30.png)
Fig.2 EEMD
![music_ceemdan.png](https://i.loli.net/2019/03/17/5c8e422d59084.png)
Fig.3 CEEMDAN
* * *
I debugged it and found out why the `Original signal` is changed: the function `ceemdan` changed it. **It may need to be scaled inside the function but it shouldn't affect the outside one**. That is why my `copy` action worked. But it dosesn't slove the problem because I just changed the usage of it.
* * *
I don't think input signal should changed outside the function `ceemdan` and fixed it in a better way instead of just change the usage of it. For the reason why it works, one can refer to https://stackoverflow.com/questions/22054698/python-modifying-list-inside-a-function
The result of CEEMDAN after I fixed it:
![music_ceemdan_fixed.png](https://i.loli.net/2019/03/17/5c8e505744d0a.png)
Fig.4 Fixed CEEMDAN


**Attention:** One may need to run `python setup.py install` again to update the function.
* * *
The code when I use CEEMDAN to dcoposite the music (from:http://www.music.helsinki.fi/tmt/opetus/uusmedia/esim/index-e.html):
    
```python
import wave 
import numpy as np
import pylab as plt
from PyEMD import CEEMDAN

max_imf = -1

# Import music
filename= 'a2002011001-e02-8kHz.wav'
f = wave.open(filename,'rb')
params = f.getparams()
nchannels, sampwidth, framerate, nframes = params[:4]
strData = f.readframes(nframes)
waveData = np.fromstring(strData,dtype=np.int16)
waveData = waveData*1.0/(max(abs(waveData))) #Normalize
waveData = np.reshape(waveData,[nframes,nchannels])
f.close()

time = np.arange(0,nframes)*(1.0 / framerate)

t = time[:4000]
tMin = t[1]
tMax = t[-1]
S = waveData[:4000,0]

# Prepare and run CEEMDAN
ceemdan = CEEMDAN()

C_IMFs = ceemdan(S, t, max_imf)
imfNo  = C_IMFs.shape[0]

# Plot results in a grid
c = np.floor(np.sqrt(imfNo+2))
r = np.ceil((imfNo+2)/c)

plt.ioff()
plt.figure(figsize=(10,10))
plt.subplot(r,c,1)
plt.plot(t, S, 'r')
plt.xlim((tMin, tMax))
plt.title("Original signal")
for num in range(imfNo):
    plt.subplot(r,c,num+2)
    plt.plot(t, C_IMFs[num],'g')
    plt.xlim((tMin, tMax))
    plt.title("Imf "+str(num+1))

plt.show()
```
    