### PR TITLE
Fix CEEMDAN and test it

### DIFF
--- a/PyEMD/CEEMDAN.py
+++ b/PyEMD/CEEMDAN.py
@@ -169,7 +169,7 @@ class CEEMDAN:
     def ceemdan(self, S, T=None, max_imf=-1):
 
         scale_s = np.std(S)
-        S[:] = S/scale_s
+        S = S/scale_s
 
         # Define all noise
         self.all_noises = self.generate_noise(1, (self.trials,S.size))
@@ -222,6 +222,9 @@ class CEEMDAN:
         res = S - np.sum(all_cimfs, axis=0)
         all_cimfs = np.vstack((all_cimfs,res))
         all_cimfs = all_cimfs*scale_s
+
+        # Emptyfy all IMFs noise
+        del self.all_noise_EMD[:]
 
         return all_cimfs
 

--- a/PyEMD/tests/test_ceemdan.py
+++ b/PyEMD/tests/test_ceemdan.py
@@ -151,5 +151,22 @@ class CEEMDANTest(unittest.TestCase):
         msg_true = "Used same seed, expected same results"
         self.assertTrue(np.all(cmpMachEps(cIMF2,cIMF3)), msg_true)
 
+    def test_ceemdan_origianlSignal(self):
+        T = np.linspace(0, 1, 100)
+        S = 2*np.cos(3*np.pi*T) + np.cos(2*np.pi*T+ 4**T)
+
+        # Make a copy of S for comparsion
+        Scopy = np.copy(S)
+
+        # Compare up to machine epsilon
+        cmpMachEps = lambda x, y: np.abs(x-y)<=2*np.finfo(x.dtype).eps
+
+        ceemdan = CEEMDAN(trials=10)
+        ceemdan(S)
+
+        # The original signal should not be changed after the 'ceemdan' function.
+        msg_true = "Expected no change of the original signal"
+        self.assertTrue(np.all(cmpMachEps(Scopy,S)), msg_true)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
1. The original signal `S` should not be changed. So I use `S[:] = S/scale_s` instead of `S = S/scale_s` to fix it.
2. Add a test case that reflects what I am trying to fix.
3. When I call the function `ceemdan` multiple times in one main program, the program will only use the random noise which was generated in the first call, though the different random seed is given before each call. So I cleaned the relevant list/array after each call to the function. Maybe there will be a better way to fix that? I need some help.
* * *
I understand signal processing is not something that can be sloppy, so I test it to check I have Fixed that: _(IMFs' [MD5](https://docs.python.org/3.6/library/hashlib.html) is calculated to make sure the IMFs in a different case is same or not)_

**Before:** (seed=114514, MD5=f5ac70aa2e917d87187d8b76207354e0)
![before_seed114514-f5ac70aa2e917d87187d8b76207354e0.png](https://i.loli.net/2019/03/19/5c9099bee090a.png)
Fig.1 case A.1
The original Signal is scaled and the residuum is wrong.

**After:** (seed=114514, MD5=f5ac70aa2e917d87187d8b76207354e0)
![after_seed114514-f5ac70aa2e917d87187d8b76207354e0.png](https://i.loli.net/2019/03/19/5c9099bfe4823.png)
Fig.2 case A.2

**Before:** (seed=89889, MD5=0b528aef0f9c710ef02a66685dd4e8ea)
![before_seed89889-0b528aef0f9c710ef02a66685dd4e8ea.png](https://i.loli.net/2019/03/19/5c9099bfe5836.png)
Fig.3 case B.1

**After:** (seed=89889, MD5=0b528aef0f9c710ef02a66685dd4e8ea)
![after_seed89889-0b528aef0f9c710ef02a66685dd4e8ea.png](https://i.loli.net/2019/03/19/5c9099bfe6cda.png)
Fig.4 case B.2

**After:** (random seed, MD5=9452d9dd49ba9f16a7eb18d60519bf31)
![after_randomSeed-9452d9dd49ba9f16a7eb18d60519bf31.png](https://i.loli.net/2019/03/19/5c9099bfe5a84.png)
Fig.5 case C

**After:** (another random seed, MD5=cc2aa1a1d229899e64f59a88090ead5e)
![after_randomSeed-cc2aa1a1d229899e64f59a88090ead5e.png](https://i.loli.net/2019/03/19/5c9099bfe505f.png)
Fig.6 case D

Obviously what I did does not change the IMFs (if the random seed is the same).
* * *
Sample code of the case A.2 is here:
```python
import wave
import numpy as np
import pylab as plt
import hashlib

from PyEMD import CEEMDAN#, Visualisation#, EMD, Visualisation

# CEEMDAN options
max_imf = -1

# Import acoustic signal
N = 513
tMin, tMax = 0, 1
t = np.linspace(tMin, tMax, N)

sin = lambda x, p: np.sin(2*np.pi*x*t+p)
S = 3*np.sin(15*2*np.pi*t*(t-0.8)**2)
S += 2*np.sin(18*2*np.pi*t*(0.3*t))
S += 4*sin(14, 2.7)*(t+0.2)**1.5
S += t**1.7 -t

# Prepare and run CEEMDAN
ceemdan = CEEMDAN()

seed = 114514
ceemdan.noise_seed(seed)
C_IMFs = ceemdan(S, t, max_imf)

m2 = hashlib.md5()
m2.update(C_IMFs)
md5 = m2.hexdigest()
print("the MD5 of IMFs is:"+md5)

imfNo  = C_IMFs.shape[0]

# Plot results in a grid
c = np.floor(np.sqrt(imfNo+2))
r = np.ceil((imfNo+2)/c)

plt.ioff()
plt.figure(figsize=(10,10))

plt.subplot(r,c,1)
plt.plot(t, S, 'r')
plt.xlim((tMin, tMax))
plt.title("Original signal")

plt.subplot(r,c,2)
plt.plot(t, S-np.sum(C_IMFs, axis=0), 'r')
plt.xlim((tMin, tMax))
plt.title("Residuum")

for num in range(imfNo):
    plt.subplot(r,c,num+3)
    plt.plot(t, C_IMFs[num],'g')
    plt.xlim((tMin, tMax))
    plt.title("Imf "+str(num+1))

plt.savefig("after_seed"+str(seed)+"-"+md5)
print("Done")
```