### PR TITLE
Huge speedup by small refactor

### DIFF
--- a/PyEMD/EMD.py
+++ b/PyEMD/EMD.py
@@ -737,7 +737,8 @@ class EMD:
         S : numpy array,
             Input signal.
         T : numpy array, (default: None)
-            Position or time array. If None passed numpy arange is created.
+            Position or time array. If None passed or if self.extrema_detection == "simple",
+            then numpy arange is created.
         max_imf : int, (default: -1)
             IMF number to which decomposition should be performed.
             Negative value means *all*.
@@ -747,8 +748,9 @@ class EMD:
         IMF : numpy array
             Set of IMFs produced from input signal.
         """
-
-        T = np.arange(len(S), dtype=S.dtype)
+        if T is None or self.extrema_detection == "simple":
+            T = np.arange(len(S), dtype=S.dtype)
+        
         if max_imf is None: max_imf = -1
 
         # Make sure same types are dealt

--- a/PyEMD/EMD.py
+++ b/PyEMD/EMD.py
@@ -308,8 +308,8 @@ class EMD:
         """
 
         # Find indexes of pass
-        ind_min = np.array([np.nonzero(T==t)[0] for t in min_pos]).flatten()
-        ind_max = np.array([np.nonzero(T==t)[0] for t in max_pos]).flatten()
+        ind_min = min_pos.astype(int)
+        ind_max = max_pos.astype(int)
 
         # Local variables
         nbsym = self.nbsym
@@ -748,7 +748,7 @@ class EMD:
             Set of IMFs produced from input signal.
         """
 
-        if T is None: T = np.arange(len(S), dtype=S.dtype)
+        T = np.arange(len(S), dtype=S.dtype)
         if max_imf is None: max_imf = -1
 
         # Make sure same types are dealt


### PR DESCRIPTION
There are two lines in the current version that might take up most of the time when performing `EMD.emd()` - lines 311 and 312 in EMD.py, function `_prepare_points_simple`:

```python
ind_min = np.array([np.nonzero(T==t)[0] for t in min_pos]).flatten()
ind_max = np.array([np.nonzero(T==t)[0] for t in max_pos]).flatten()
```

What these lines do is basically find the indices of array `T` where the signal `S` reaches its maximum or minimum. The difference between `min_pos` and `ind_min` is that the former contains the values in units of `T`, while the latter contains the indices of the array (0,1,2,..) in the numpy-sense. It is obvious that these two arrays are equal to each other (up to type difference), if the array `T == np.arange(len(S))`. 

The problem is that `T` is not always an `np.arange`, and it can be passed to `EMD.emd()` as an optional argument. However, I don't see a reason why it cannot be overwritten for performance reasons, since EMD is in some sense a timescale-invariant transformation.

It didn't dive into implementation details to prove myself wrong, by I ran a couple of experiments and found out that forcing the array `T` to be `np.arange` actually _does result_ in different IMFs, but the difference is almost on the order of machine precision:

![image](https://user-images.githubusercontent.com/12871516/54990070-eaa23d80-4fca-11e9-89f8-0cc26416dff0.png)

In the figure above, the red line on the left is the original signal given by

```
t = np.arange(0,10,0.005)
s = np.sin(t) + 11*np.sin(5*t) + 7*np.cos(6*t) + 4*t + np.random.randn(len(t))
```

The right blue lines are the difference for the first 4 IMFs between the `EMD` based on the original `T` and the "simplified" `T = np.arange(len(S), dtype=S.dtype)`.

### Speedup proof.

To show that proposed changes actually result in a speedup, I show the `%timeit` results for two setups: for a signal with large ("noisy") or small ("noiseless") numbers of local optima. We run the decompositions for signal with different number of observations. The setup is:

```python
n_obs = 10 # 100, 500, 1000, 5000, 10000
t = np.linspace(0,1,n_obs+1)
s1 = np.cos(22*np.pi*t**2) + 6*t**2    # small num of local optima, "noiseless"
s2 = s1 + 0.1*np.random.randn(len(t))  # large num of local optima, "noisy"
```

The results are (in ms):

Num of obs | Noiseless, current version | Noiseless, proposed version | Noisy, current version | Noisy, proposed version
-- | -- | -- | -- | --
10 | 2.29 | 2.24 | 4.35 | 4.23
100 | 2.48 | 2.29 | 7.81 | 7.35
500 | 2.95 | 2.75 | 37.10 | 25.80
1000 | 2.99 | 2.82 | 89.50 | 46.70
5000 | 5.02 | 4.75 | 569.00 | 158.00
10000 | 7.60 | 7.18 | 2160.00 | 277.00

![image](https://user-images.githubusercontent.com/12871516/54993064-0230f480-4fd2-11e9-835c-037ebcc16aae.png)

It is clearly seen, that the speedup may reach almost an order of magnitude for signals with large number of local optima. Thus, the proposed change will make the noise-assisted ensemble methods work much faster.

Please, review this and contact me if more change or testing is needed.