### PR TITLE
Few fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
   - 2.7
-  - 3.4
   - 3.5
+  - 3.6
+  - 3.7
 # command to run tests
 before_install:
   - pip install --upgrade pip setuptools wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - 2.7
   - 3.5
   - 3.6
-  - 3.7
 # command to run tests
 before_install:
   - pip install --upgrade pip setuptools wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
 install:
   - pip install --only-binary=numpy,scipy numpy scipy
   - pip install -r requirements.txt
+  - pip install -r requirements-extra.txt
   - pip install codecov
 script: 
   - python -m PyEMD.tests.test_all

--- a/PyEMD/BEMD.py
+++ b/PyEMD/BEMD.py
@@ -16,7 +16,8 @@ from scipy.interpolate import Rbf
 try:
     from skimage.morphology import reconstruction
 except ImportError:
-    pass
+    raise ImportError("EMD2D and BEMD are not supported. Feel free to play around and improve them. " + \
+            "Required depdenecies are in `requriements-extra`.")
 
 class BEMD:
     """

--- a/PyEMD/EMD.py
+++ b/PyEMD/EMD.py
@@ -726,7 +726,7 @@ class EMD:
 
         return x, y
 
-    def emd(self, S, T=None, max_imf=None):
+    def emd(self, S, T=None, max_imf=-1):
         """
         Performs Empirical Mode Decomposition on signal S.
         The decomposition is limited to *max_imf* imfs.
@@ -748,10 +748,11 @@ class EMD:
         IMF : numpy array
             Set of IMFs produced from input signal.
         """
+        if T is not None and len(S) != len(T):
+            raise ValueError("Time series have different sizes: len(S) -> {} != {} <- len(T)".format(len(S), len(T)))
+
         if T is None or self.extrema_detection == "simple":
             T = np.arange(len(S), dtype=S.dtype)
-        
-        if max_imf is None: max_imf = -1
 
         # Make sure same types are dealt
         S, T = self._common_dtype(S, T)

--- a/PyEMD/EMD2d.py
+++ b/PyEMD/EMD2d.py
@@ -13,10 +13,13 @@ from __future__ import division, print_function
 import logging
 import numpy as np
 
-#from scipy.ndimage import maximum_filter
-from scipy.ndimage.filters import maximum_filter
-from scipy.ndimage.morphology import generate_binary_structure, binary_erosion
-from scipy.interpolate import SmoothBivariateSpline as SBS
+try:
+    from scipy.ndimage.filters import maximum_filter
+    from scipy.ndimage.morphology import generate_binary_structure, binary_erosion
+    from scipy.interpolate import SmoothBivariateSpline as SBS
+except ImportError:
+    raise ImportError("EMD2D and BEMD are not supported. Feel free to play around and improve them. " + \
+            "Required depdenecies are in `requriements-extra`.")
 
 class EMD2D:
     """

--- a/PyEMD/__init__.py
+++ b/PyEMD/__init__.py
@@ -1,17 +1,9 @@
 import logging
 
 logger = logging.getLogger('pyemd')
-logger.addHandler(logging.NullHandler())
-if len(logger.handlers)==1:
-    logging.basicConfig(level=logging.INFO)
 
 from PyEMD.EMD import EMD
 from PyEMD.EEMD import EEMD
 from PyEMD.CEEMDAN import CEEMDAN
 from PyEMD.visualisation import Visualisation
 
-try:
-    from PyEMD.EMD2d import EMD2D
-    from PyEMD.BEMD import BEMD
-except ImportError:
-    logger.debug("EMD2D and BEMD are not supported in the basic version. They are dependent on packages in the `requriements-extra`.")

--- a/PyEMD/splines.py
+++ b/PyEMD/splines.py
@@ -23,9 +23,9 @@ def cubic_spline_3pts(x, y, T):
     v3 = 3*y2y1*_x2x1*_x2x1
     v2 = v1+v3
 
-    M = np.matrix([[m11,m12,m13],[m21,m22,m23],[m31,m32,m33]])
-    v = np.matrix([v1,v2,v3]).T
-    k = np.array(np.linalg.inv(M)*v)
+    M = np.array([[m11,m12,m13],[m21,m22,m23],[m31,m32,m33]])
+    v = np.array([v1,v2,v3]).T
+    k = np.array(np.linalg.inv(M).dot(v))
 
     a1 = k[0]*x1x0 - y1y0
     b1 =-k[1]*x1x0 + y1y0

--- a/PyEMD/tests/test_bemd.py
+++ b/PyEMD/tests/test_bemd.py
@@ -3,7 +3,7 @@
 import unittest
 import numpy as np
 
-from PyEMD import BEMD
+from PyEMD.BEMD import BEMD
 
 @unittest.skip
 class BEMDTest(unittest.TestCase):

--- a/PyEMD/tests/test_emd2d.py
+++ b/PyEMD/tests/test_emd2d.py
@@ -4,7 +4,7 @@
 from __future__ import division, print_function
 
 import numpy as np
-from PyEMD import EMD2D
+from PyEMD.EMD2d import EMD2D
 import unittest
 
 @unittest.skip

--- a/PyEMD/tests/test_extrema.py
+++ b/PyEMD/tests/test_extrema.py
@@ -121,7 +121,7 @@ class ExtremaTest(unittest.TestCase):
         ## CASE 2
         # L2, R2 -- edge MIN, edge MIN
         s = S[1:-1].copy()
-        t = T[1:-1].copy()
+        t = np.arange(s.size)
 
         maxPos, maxVal, minPos, minVal, nz = emd.find_extrema(t, s)
 
@@ -129,14 +129,15 @@ class ExtremaTest(unittest.TestCase):
         maxExtrema, minExtrema = pp(t, s, \
                         maxPos, maxVal, minPos, minVal)
 
-        self.assertEqual([-1,3,9,14,20], maxExtrema[0].tolist())
+        self.assertEqual([-2,2,8,13,19], maxExtrema[0].tolist())
         self.assertEqual([4,4,2,5,5], maxExtrema[1].tolist())
-        self.assertEqual([1,6,11,17], minExtrema[0].tolist())
+        self.assertEqual([0,5,10,16], minExtrema[0].tolist())
         self.assertEqual([-3,-2,0,-2], minExtrema[1].tolist())
 
         ## CASE 3
         # L3, R3 -- no edge MAX & no edge MAX
-        s, t = S[2:-3], T[2:-3]
+        s = S[2:-3].copy()
+        t = np.arange(s.size)
 
         maxPos, maxVal, minPos, minVal, nz = emd.find_extrema(t, s)
 
@@ -144,14 +145,15 @@ class ExtremaTest(unittest.TestCase):
         maxExtrema, minExtrema = pp(t, s, \
                         maxPos, maxVal, minPos, minVal)
 
-        self.assertEqual([-3,3,9,14,19], maxExtrema[0].tolist())
+        self.assertEqual([-5,1,7,12,17], maxExtrema[0].tolist())
         self.assertEqual([2,4,2,5,2], maxExtrema[1].tolist())
-        self.assertEqual([0,6,11,17], minExtrema[0].tolist())
+        self.assertEqual([-2,4,9,15], minExtrema[0].tolist())
         self.assertEqual([-2,-2,0,0], minExtrema[1].tolist())
 
         ## CASE 4
         # L4, R4 -- edge MAX & edge MAX
-        s, t = S[3:-4], T[3:-4]
+        s = S[3:-4].copy()
+        t = np.arange(s.size)
 
         maxPos, maxVal, minPos, minVal, nz = emd.find_extrema(t, s)
 
@@ -159,9 +161,9 @@ class ExtremaTest(unittest.TestCase):
         maxExtrema, minExtrema = pp(t, s, \
                         maxPos, maxVal, minPos, minVal)
 
-        self.assertEqual([3,9,14], maxExtrema[0].tolist())
+        self.assertEqual([0,6,11], maxExtrema[0].tolist())
         self.assertEqual([4,2,5], maxExtrema[1].tolist())
-        self.assertEqual([0,6,11,17], minExtrema[0].tolist())
+        self.assertEqual([-3,3,8,14], minExtrema[0].tolist())
         self.assertEqual([-2,-2,0,0], minExtrema[1].tolist())
 
     def test_find_extrema_parabol(self):


### PR DESCRIPTION
* Fixes failing tests due to previous pull request. With `simple` extrema detection we create a new index array and ignore whatever is provided. Tests dependent on provided index arrays.
* Disable logging configuration. Let the user define these configuration themselves, otherwise we override global setting (`logging` module is a singleton).
* Moved `BEMD` and `EMD2D` from `PyEMD` import.
* Updated **Travis** to check Python3.6 and ignore Python3.4. Main reason for skipping Python3.4 is that `scikit-image` don't support it which we use for `BEMD` and `EMD2D`, so that's not a deal breaker. If needed, this can be reverted.