### PR TITLE
Bug fix - First IMF obtained from EEMD with zeros

### DIFF
--- a/PyEMD/CEEMDAN.py
+++ b/PyEMD/CEEMDAN.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 
 import logging
 import numpy as np
+import itertools
 
 from multiprocessing import Pool
 
@@ -295,11 +296,12 @@ class CEEMDAN:
         else:  # Not parallel
             all_IMFs = map(self._trial_update, range(self.trials))
 
-
-        max_imfNo = max([IMFs.shape[0] for IMFs in all_IMFs])
+        all_IMFs_1, all_IMFs_2 = itertools.tee(all_IMFs, 2)
+        
+        max_imfNo = max([IMFs.shape[0] for IMFs in all_IMFs_1])
 
         self.E_IMF = np.zeros((max_imfNo, N))
-        for IMFs in all_IMFs:
+        for IMFs in all_IMFs_2:
             self.E_IMF[:IMFs.shape[0]] += IMFs
 
         return self.E_IMF/self.trials


### PR DESCRIPTION
The `_eemd` method was being applied to get the first IMF, and it was returning a null IMF. That is because the iterator `all_IMFs` was being used more than once, which would raise a StopIteration exception after its first use. Then, the code wasn't entering the loop to give values to E_IMF because all_IMFs was an empty list. There are 2 ways to fix this problem: (1) simply convert the iterator to a list before the next use, or (2) create two more iterators using itertools.tee. In this commit, option (2) is employed.