### PR TITLE
Improvements in visualization module

### DIFF
--- a/PyEMD/CEEMDAN.py
+++ b/PyEMD/CEEMDAN.py
@@ -112,6 +112,9 @@ class CEEMDAN:
         self.range_thr = 0.01
         self.total_power_thr = 0.05
 
+        self.C_IMF = None
+        self.residue = None
+
         # Update based on options
         for key in config.keys():
             if key in self.__dict__.keys() or key == "processes":
@@ -225,6 +228,9 @@ class CEEMDAN:
         # Emptyfy all IMFs noise
         del self.all_noise_EMD[:]
 
+        self.C_IMF = all_cimfs
+        self.residue = S*scale_s - np.sum(self.C_IMF, axis=0)
+
         return all_cimfs
 
     def end_condition(self, S, cIMFs, max_imf):
@@ -318,6 +324,16 @@ class CEEMDAN:
         For reference please see :class:`PyEMD.EMD`.
         """
         return self.EMD.emd(S, T, max_imf)
+
+    def get_imfs_and_residue(self):
+        """
+        Provides access to separated imfs and residue from recently analysed signal.
+        :return: (imfs, residue)
+        """
+        if self.C_IMF is None or self.residue is None:
+            raise ValueError('No IMF found. Please, run EMD method or its variant first.')
+        else:
+            return self.C_IMF, self.residue
 
 ###################################################
 ## Beginning of program

--- a/PyEMD/EEMD.py
+++ b/PyEMD/EEMD.py
@@ -85,6 +85,9 @@ class EEMD:
         else:
             self.EMD = ext_EMD
 
+        self.E_IMF = None
+        self.residue = None
+
         # Update based on options
         for key in config.keys():
             if key in self.__dict__.keys() or key == "processes":
@@ -191,7 +194,10 @@ class EEMD:
         for IMFs in all_IMFs_2:
             self.E_IMF[:IMFs.shape[0]] += IMFs
 
-        return self.E_IMF/self.trials
+        self.E_IMF /= self.trials
+        self.residue = S - np.sum(self.E_IMF, axis=0)
+
+        return self.E_IMF
 
     def _trial_update(self, trial):
         # Generate noise
@@ -205,6 +211,16 @@ class EEMD:
         For reference please see :class:`PyEMD.EMD`.
         """
         return self.EMD.emd(S, T, max_imf)
+
+    def get_imfs_and_residue(self):
+        """
+        Provides access to separated imfs and residue from recently analysed signal.
+        :return: (imfs, residue)
+        """
+        if self.E_IMF is None or self.residue is None:
+            raise ValueError('No IMF found. Please, run EMD method or its variant first.')
+        else:
+            return self.E_IMF, self.residue
 
 ###################################################
 ## Beginning of program

--- a/PyEMD/EMD.py
+++ b/PyEMD/EMD.py
@@ -860,7 +860,10 @@ class EMD:
         Provides access to separated imfs and residue from recently analysed signal.
         :return: (imfs, residue)
         """
-        return self.imfs, self.residue
+        if self.imfs is None or self.residue is None:
+            raise ValueError('No IMF found. Please, run EMD method or its variant first.')
+        else:
+            return self.imfs, self.residue
 
 ###################################################
 

--- a/PyEMD/compact.py
+++ b/PyEMD/compact.py
@@ -1,0 +1,139 @@
+import numpy as np
+
+
+def TDMAsolver(a, b, c, d):
+    """Thomas algorithm to solve tridiagonal linear systems with
+    non-periodic BC.
+
+    | b0  c0                 | | . |     | . |
+    | a1  b1  c1             | | . |     | . |
+    |     a2  b2  c2         | | x |  =  | d |
+    |         ..........     | | . |     | . |
+    |             an  bn  cn | | . |     | . |
+    """
+    n = len(b)
+
+    cp = np.zeros(n)
+    cp[0] = c[0]/b[0]
+    for i in range(1, n-1):
+        cp[i] = c[i] / ( b[i] - a[i]*cp[i-1] )
+
+    dp = np.zeros(n)
+    dp[0] = d[0]/b[0]
+    for i in range(1, n):
+        dp[i] = ( d[i] - a[i]*dp[i-1] ) / ( b[i] - a[i]*cp[i-1] )
+
+    x = np.zeros(n)
+    x[-1] = dp[-1]
+    for i in range(n-2, -1, -1):
+        x[i] = dp[i] - cp[i] * x[i+1]
+
+    return x
+
+def filt6(f, alpha):
+    """
+    6th Order compact filter (non-periodic BC).
+
+    References:
+    -----------
+    Lele, S. K. - Compact finite difference schemes with spectral-like
+    resolution. Journal of Computational Physics 103 (1992) 16-42
+
+    Visbal, M. R. and Gaitonde, D. V. - On the use of higher-order finite-
+    difference schemes on curvilinear and deforming meshes. Journal of
+    Computational Physics 181 (2002) 155-185
+    """
+    Ca = (11.0 + 10.0*alpha)/16.0
+    Cb = (15.0 + 34.0*alpha)/32.0
+    Cc = (-3.0 + 6.0*alpha)/16.0
+    Cd = (1.0 - 2.0*alpha)/32.0
+
+    n = len(f)
+
+    rhs  = np.zeros(n)
+
+    rhs[3:-3] = Cd*0.5*( f[6:] + f[:-6] ) + \
+                Cc*0.5*( f[5:-1] + f[1:-5] ) + \
+                Cb*0.5*( f[4:-2] + f[2:-4] ) + \
+                Ca*f[3:-3]
+
+    # Non-periodic BC:
+    rhs[0] = (15.0/16.0)*f[0] + (4.0*f[1] - 6.0*f[2] + 4.0*f[3] - f[4])/16.0
+
+    rhs[1] = (3.0/4.0)*f[1] + (f[0] + 6.0*f[2] - 4.0*f[3] + f[4])/16.0
+
+    rhs[2] = (5.0/8.0)*f[2] + (-f[0] + 4.0*f[1] + 4.0*f[3] - f[4])/16.0
+
+    rhs[-1] = (15.0/16.0)*f[-1] + (4.0*f[-2] - 6.0*f[-3] + 4.0*f[-4] - f[-5])/16.0
+
+    rhs[-2] = (3.0/4.0)*f[-2] + (f[-1] + 6.0*f[-3] - 4.0*f[-4] + f[-5])/16.0
+
+    rhs[-3] = (5.0/8.0)*f[-3] + (-f[-1] + 4.0*f[-2] + 4.0*f[-4] - f[-5])/16.0
+
+    Da = alpha*np.ones(n)
+    Db = np.ones(n)
+    Dc = alpha*np.ones(n)
+
+    # 1st point
+    Dc[0] = 0.0
+    # 2nd point
+    Da[1] = Dc[1] = 0.0
+    # 3rd point
+    Da[2] = Dc[2] = 0.0
+    # last point
+    Da[-1] = 0.0
+    # 2nd from last
+    Da[-2] = Dc[-2] = 0.0
+    # 3rd from last
+    Da[-3] = Dc[-3] = 0.0
+
+    return TDMAsolver(Da, Db, Dc, rhs)
+
+def pade6(vec, h):
+    """
+    6th Order compact finite difference scheme (non-periodic BC).
+
+    Lele, S. K. - Compact finite difference schemes with spectral-like
+    resolution. Journal of Computational Physics 103 (1992) 16-42
+    """
+    n = len(vec)
+    rhs = np.zeros(n)
+
+    a = 14.0/18.0
+    b = 1.0/36.0
+
+    rhs[2:-2] = (vec[3:-1] - vec[1:-3])*(a/h) + (vec[4:] - vec[0:-4])*(b/h)
+
+    # boundaries:
+    rhs[0] = ((-197.0/60.0)*vec[0] + (-5.0/12.0)*vec[1] + 5.0*vec[2] + \
+        (-5.0/3.0)*vec[3] + (5.0/12.0)*vec[4] + (-1.0/20.0)*vec[5])/h
+
+    rhs[1] = ((-20.0/33.0)*vec[0] + (-35.0/132.0)*vec[1] + \
+        (34.0/33.0)*vec[2] + (-7.0/33.0)*vec[3] + (2.0/33.0)*vec[4] + \
+        (-1.0/132.0)*vec[5])/h
+
+    rhs[-1] = ((197.0/60.0)*vec[-1] + (5.0/12.0)*vec[-2] + \
+        (-5.0)*vec[-3] + (5.0/3.0)*vec[-4] + (-5.0/12.0)*vec[-5] + \
+        (1.0/20.0)*vec[-6])/h
+
+    rhs[-2] = ((20.0/33.0)*vec[-1] + (35.0/132.0)*vec[-2] + \
+        (-34.0/33.0)*vec[-3] + (7.0/33.0)*vec[-4] + (-2.0/33.0)*vec[-5] + \
+        (1.0/132.0)*vec[-6])/h
+
+    alpha1 = 5.0 # j = 1 and n
+    alpha2 = 2.0/11 # j = 2 and n-1
+    alpha = 1.0/3.0
+
+    Db = np.ones(n)
+    Da = alpha*np.ones(n)
+    Dc = alpha*np.ones(n)
+
+    # boundaries:
+    Da[1] = alpha2
+    Da[-1] = alpha1
+    Da[-2] = alpha2
+    Dc[0] = alpha1
+    Dc[1] = alpha2
+    Dc[-2] = alpha2
+
+    return TDMAsolver(Da, Db, Dc, rhs)

--- a/PyEMD/tests/test_ceemdan.py
+++ b/PyEMD/tests/test_ceemdan.py
@@ -177,6 +177,20 @@ class CEEMDANTest(unittest.TestCase):
         self.assertTrue(cIMFs.shape[0]>1)
         self.assertTrue(cIMFs.shape[1]==S.size)
 
+    def test_imfs_and_residue_accessor(self):
+        S = np.random.random(100)
+        ceemdan = CEEMDAN(parallel=False)
+        cIMFs = ceemdan(S)
+
+        imfs, residue = ceemdan.get_imfs_and_residue()
+        self.assertEqual(cIMFs.shape[0], imfs.shape[0], "Compare number of components")
+        self.assertEqual(len(residue), 100, "Check if residue exists")
+
+    def test_imfs_and_residue_accessor2(self):
+        ceemdan = CEEMDAN()
+        with self.assertRaises(ValueError):
+            imfs, residue = ceemdan.get_imfs_and_residue()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/PyEMD/tests/test_compact.py
+++ b/PyEMD/tests/test_compact.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+# Coding: UTF-8
+
+from __future__ import print_function
+
+import numpy as np
+import scipy as sp
+import scipy.sparse
+from PyEMD.compact import *
+import unittest
+
+
+class CompactTest(unittest.TestCase):
+
+    @staticmethod
+    def create_signal():
+        # Do NOT modify this function! If you do, the following can happen:
+        # -- Possible test errors for filter (tolerace of np.allclose).
+        # -- Error in the derivative test (analytical derivative is hardcoded)
+        t = np.linspace(0.0, np.pi, 200)
+        return 0.1*np.cos(2.0*np.pi*t)
+
+    def test_TDMA(self):
+
+        diags = np.array([0.5*np.ones(10), 1.0*np.ones(10), 0.5*np.ones(10)])
+        positions = [-1, 0, 1]
+        tridiag = sp.sparse.spdiags(diags, positions, 10, 10).todense()
+
+        # change some diagonal values to make sure it is working
+        diags[0][3] = 2.0
+        diags[1][1] = 2.0
+        tridiag[3, 2] = 2.0
+        tridiag[1, 1] = 2.0
+
+        rhs = np.arange(10)
+
+        answer = np.linalg.solve(tridiag, rhs)
+        #result = TDMAsolver(*diags, rhs)
+        result = TDMAsolver(diags[0], diags[1], diags[2], rhs)
+
+        self.assertTrue(np.allclose(answer, result))
+
+    def test_filter_off(self):
+        S = self.create_signal()
+        self.assertTrue(np.allclose(S, filt6(S, 0.5), atol=1e-5))
+
+    def test_filter_small(self):
+        S = self.create_signal()
+        self.assertTrue(np.allclose(S, filt6(S, 0.45), atol=1e-5))
+
+    def test_filter_medium(self):
+        S = self.create_signal()
+        self.assertTrue(np.allclose(S, filt6(S, 0.0), atol=1e-5))
+
+    def test_filter_high(self):
+        S = self.create_signal()
+        self.assertTrue(np.allclose(S, filt6(S, -0.5), atol=1e-5))
+
+    def test_pade6(self):
+        t = np.linspace(0.0, np.pi, 200)
+        S = self.create_signal()
+        Sprime = -0.1*2.0*np.pi*np.sin(2.0*np.pi*t)
+        self.assertTrue(np.allclose(Sprime, pade6(S, t[1]-t[0]), atol=1e-5))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/PyEMD/tests/test_eemd.py
+++ b/PyEMD/tests/test_eemd.py
@@ -129,5 +129,20 @@ class EEMDTest(unittest.TestCase):
         self.assertTrue(eIMFs.shape[1], len(S))
         self.assertFalse('pool' in eemd.__dict__)
 
+    def test_imfs_and_residue_accessor(self):
+        S = np.random.random(100)
+        eemd = EEMD(trials=5, max_imf=2, parallel=False)
+        eIMFs = eemd(S)
+
+        imfs, residue = eemd.get_imfs_and_residue()
+        self.assertEqual(eIMFs.shape[0], imfs.shape[0], "Compare number of components")
+        self.assertEqual(len(residue), 100, "Check if residue exists")
+
+    def test_imfs_and_residue_accessor2(self):
+        eemd = EEMD()
+        with self.assertRaises(ValueError):
+            imfs, residue = eemd.get_imfs_and_residue()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/PyEMD/tests/test_emd.py
+++ b/PyEMD/tests/test_emd.py
@@ -199,6 +199,11 @@ class EMDTest(unittest.TestCase):
         self.assertTrue(np.array_equal(all_imfs[:-1], imfs), "Shouldn't matter where imfs are from")
         self.assertTrue(np.array_equal(all_imfs[-1], residue), "Residue, if any, is the last row")
 
+    def test_imfs_and_residue_accessor2(self):
+        emd = EMD()
+        with self.assertRaises(ValueError):
+            imfs, residue = emd.get_imfs_and_residue()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/PyEMD/tests/test_visualization.py
+++ b/PyEMD/tests/test_visualization.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python
+# Coding: UTF-8
+
+from __future__ import print_function
+
+import numpy as np
+from PyEMD import EMD, EEMD, CEEMDAN
+from PyEMD.visualisation import Visualisation
+import unittest
+
+class VisTest(unittest.TestCase):
+
+    def test_instantiation(self):
+        emd = EMD()
+        with self.assertRaises(ValueError):
+            Visualisation(emd)
+
+    def test_instantiation2(self):
+        t = np.linspace(0, 1, 50)
+        S = t + np.cos(np.cos(4.*t**2))
+        emd = EMD()
+        emd.emd(S, t)
+        imfs, res = emd.get_imfs_and_residue()
+        vis = Visualisation(emd)
+        assert (vis.imfs == imfs).all()
+        assert (vis.residue == res).all()
+
+    def test_check_imfs(self):
+        vis = Visualisation()
+        imfs = np.arange(50).reshape(2,25)
+        res = np.arange(25)
+        imfs, res = vis._check_imfs(imfs, res, False)
+        assert len(imfs) == 2
+
+    def test_check_imfs2(self):
+        vis = Visualisation()
+        with self.assertRaises(AttributeError):
+            vis._check_imfs(None, None, False)
+
+    def test_check_imfs3(self):
+        vis = Visualisation()
+        imfs = np.arange(50).reshape(2,25)
+        vis._check_imfs(imfs, None, False)
+
+    def test_check_imfs4(self):
+        vis = Visualisation()
+        imfs = np.arange(50).reshape(2,25)
+        with self.assertRaises(AttributeError):
+            vis._check_imfs(imfs, None, True)
+
+    def test_check_imfs5(self):
+        t = np.linspace(0, 1, 50)
+        S = t + np.cos(np.cos(4.*t**2))
+        emd = EMD()
+        emd.emd(S, t)
+        imfs, res = emd.get_imfs_and_residue()
+        vis = Visualisation(emd)
+        imfs2, res2 = vis._check_imfs(imfs, res, False)
+        assert (imfs == imfs2).all()
+        assert (res == res2).all()
+
+    def test_plot_imfs(self):
+        vis = Visualisation()
+        with self.assertRaises(AttributeError):
+            vis.plot_imfs()
+
+    # Does not work for Python 2.7 (TravisCI), even with Agg backend
+    # def test_plot_imfs2(self):
+    #     t = np.linspace(0, 1, 50)
+    #     S = t + np.cos(np.cos(4.*t**2))
+    #     emd = EMD()
+    #     emd.emd(S, t)
+    #     vis = Visualisation(emd)
+    #     vis.plot_imfs()
+
+    def test_calc_instant_phase(self):
+        sig = np.arange(10)
+        vis = Visualisation()
+        phase = vis._calc_inst_phase(sig, None)
+        assert len(sig) == len(phase)
+
+    def test_calc_instant_phase2(self):
+        t = np.linspace(0, 1, 50)
+        S = t + np.cos(np.cos(4.*t**2))
+        emd = EMD()
+        imfs = emd.emd(S, t)
+        vis = Visualisation()
+        phase = vis._calc_inst_phase(imfs, 0.4)
+        assert len(imfs) == len(phase)
+
+    def test_calc_instant_phase3(self):
+        t = np.linspace(0, 1, 50)
+        S = t + np.cos(np.cos(4.*t**2))
+        emd = EMD()
+        imfs = emd.emd(S, t)
+        vis = Visualisation()
+        with self.assertRaises(AssertionError):
+            phase = vis._calc_inst_phase(imfs, 0.8)
+
+    def test_calc_instant_freq(self):
+        t = np.linspace(0, 1, 50)
+        S = t + np.cos(np.cos(4.*t**2))
+        emd = EMD()
+        imfs = emd.emd(S, t)
+        vis = Visualisation()
+        freqs = vis._calc_inst_freq(imfs, t, False, None)
+        assert imfs.shape == freqs.shape
+
+    def test_calc_instant_freq(self):
+        t = np.linspace(0, 1, 50)
+        S = t + np.cos(np.cos(4.*t**2))
+        emd = EMD()
+        imfs = emd.emd(S, t)
+        vis = Visualisation()
+        freqs = vis._calc_inst_freq(imfs, t, False, 0.4)
+        assert imfs.shape == freqs.shape
+
+    def test_plot_instant_freq(self):
+        vis = Visualisation()
+        t = np.arange(20)
+        with self.assertRaises(AttributeError):
+            vis.plot_instant_freq(t)
+
+    # Does not work for Python 2.7 (TravisCI), even with Agg backend
+    # def test_plot_instant_freq2(self):
+    #     t = np.linspace(0, 1, 50)
+    #     S = t + np.cos(np.cos(4.*t**2))
+    #     emd = EMD()
+    #     imfs = emd.emd(S, t)
+    #     vis = Visualisation(emd)
+    #     vis.plot_instant_freq(t, imfs=imfs, order=False, alpha=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/PyEMD/visualisation.py
+++ b/PyEMD/visualisation.py
@@ -99,7 +99,7 @@ class Visualisation(object):
         fig, axes = plt.subplots(num_rows, 1, figsize=(self.PLOT_WIDTH, num_rows*self.PLOT_HEIGHT_PER_IMF))
 
         if num_rows == 1:
-            axes = list(axes)
+            axes = fig.axes
 
         axes[0].set_title("Instantaneous frequency")
 

--- a/PyEMD/visualisation.py
+++ b/PyEMD/visualisation.py
@@ -5,6 +5,7 @@ import numpy as np
 try:
     import pylab as plt
     from scipy.signal import hilbert
+    from PyEMD.compact import filt6, pade6
 except ImportError:
     pass
 
@@ -74,16 +75,26 @@ class Visualisation(object):
         # Making the layout a bit more pleasant to the eye
         plt.tight_layout()
 
-    def plot_instant_freq(self, t, imfs=None):
+    def plot_instant_freq(self, t, imfs=None, order=False, alpha=None):
         """Plots and shows instantaneous frequencies for all provided imfs.
 
         The necessary parameter is `t` which is the time array used to compute the EMD.
         One should pass `imfs` if no `emd` instances is passed when creating the Visualisation object.
+        param bool `order`:: represents whether the finite difference scheme is
+            low-order (1st order forward scheme) or high-order (6th order
+            compact scheme). The default value is False (low-order)
+        param float `alpha`:: filter intensity. Default value is None, which
+            is equivalent to `alpha` = 0.5, meaning that no filter is applied.
+            The `alpha` values must be in between -0.5 (fully active) and 0.5
+            (no filter).
         """
+        if alpha is not None:
+            assert -0.5 < alpha < 0.5 , '`alpha` must be in between -0.5 and 0.5'
+
         imfs, _ = self._check_imfs(imfs, None, False)
         num_rows = imfs.shape[0]
 
-        imfs_inst_freqs = self._calc_inst_freq(imfs, t)
+        imfs_inst_freqs = self._calc_inst_freq(imfs, t, order=order, alpha=alpha)
 
         fig, axes = plt.subplots(num_rows, 1, figsize=(self.PLOT_WIDTH, num_rows*self.PLOT_HEIGHT_PER_IMF))
 
@@ -94,22 +105,38 @@ class Visualisation(object):
 
         for num, imf_inst_freq in enumerate(imfs_inst_freqs):
             ax = axes[num]
-            ax.plot(t[:-1], imf_inst_freq)
+            ax.plot(t, imf_inst_freq)
             ax.set_ylabel("IMF {} [Hz]".format(num+1))
 
         # Making the layout a bit more pleasant to the eye
         plt.tight_layout()
 
-    def _calc_inst_phase(self, sig):
+    def _calc_inst_phase(self, sig, alpha):
         """Extract analytical signal through the Hilbert Transform."""
         analytic_signal = hilbert(sig)  # Apply Hilbert transform to each row
+        if alpha is not None:
+            assert -0.5 < alpha < 0.5 , '`alpha` must be in between -0.5 and 0.5'
+            real_part = np.array([filt6(row.real, alpha) for row in analytic_signal])
+            imag_part = np.array([filt6(row.imag, alpha) for row in analytic_signal])
+            analytic_signal = real_part + 1j*imag_part
         phase = np.unwrap(np.angle(analytic_signal))  # Compute angle between img and real
+        if alpha is not None:
+            phase = np.array([filt6(row, alpha) for row in phase]) # Filter phase
         return phase
 
-    def _calc_inst_freq(self, sig, t):
+    def _calc_inst_freq(self, sig, t, order, alpha):
         """Extracts instantaneous frequency through the Hilbert Transform."""
-        inst_phase = self._calc_inst_phase(sig)
-        return np.diff(inst_phase)/(2*np.pi*(t[1]-t[0]))
+        inst_phase = self._calc_inst_phase(sig, alpha=alpha)
+        if order is False:
+            inst_freqs = np.diff(inst_phase)/(2*np.pi*(t[1]-t[0]))
+            inst_freqs = np.concatenate((inst_freqs,
+                inst_freqs[:,-1].reshape(inst_freqs[:,-1].shape[0],1)), axis=1)
+        else:
+            inst_freqs = [pade6(row, t[1]-t[0])/(2.0*np.pi) for row in inst_phase]
+        if alpha is None:
+            return np.array(inst_freqs)
+        else:
+            return np.array([filt6(row, alpha) for row in inst_freqs]) # Filter freqs
 
     def show(self):
         plt.show()


### PR DESCRIPTION
This request contains two main contributions:

1) Inclusion of methods to return the IMFs and the residuum of the decomposition. So that, `visualization.py` module can be readily used by EMD, EEMD and CEEMDAN. 

2) The imaginary part of the Hilbert transformed signal (from scipy) was presenting high-frequency oscillations due to numerical errors (again, from scipy), which were impairing the accuracy of the instantaneous frequency assessment. This issue was solved by passing a high-frequency filter of low strength into the signal. With that, the time-frequency evaluation of each IMFs was drastically improved. In addition, a 6th order compact scheme was added to evaluate the time derivative as an alternative for `numpy.diff`, which uses a 1st order forward scheme. This high-order differentiation can be useful in the presence of IMFs of very high frequency, but is shown to be of minor importance. Test units were included to certify the implementation of the compact operators (filter and differentiation).

A zipped jupyter notebook is attached here, where you can see the proposed fixes in depth.
[visualization_improv.zip](https://github.com/laszukdawid/PyEMD/files/4272266/visualization_improv.zip)
 
Example:
------------

Given the signal:
![signal2](https://user-images.githubusercontent.com/35971460/75629116-0b511b00-5bbe-11ea-8370-e133191d28c0.png)

Its IMFs and residue are:
![Signal2](https://user-images.githubusercontent.com/35971460/75629125-13a95600-5bbe-11ea-8519-5060529ed33e.png)

The non-filtered frequencies (before this pull request) are:
![Non-filtered2](https://user-images.githubusercontent.com/35971460/75629153-4c492f80-5bbe-11ea-8f37-30888759de39.png)

Applying filter, gives:
![Filtered2](https://user-images.githubusercontent.com/35971460/75629162-5bc87880-5bbe-11ea-8dbd-14c2a488eb65.png)


