### PR TITLE
Adjust end condition for emd decomposition

### DIFF
--- a/PyEMD/EMD.py
+++ b/PyEMD/EMD.py
@@ -908,7 +908,7 @@ class EMD:
             IMF = np.vstack((IMF, imf.copy()))
             imfNo += 1
 
-            if self.end_condition(S, IMF) or imfNo == max_imf:
+            if self.end_condition(S, IMF) or imfNo == max_imf - 1:
                 finished = True
                 break
 

--- a/PyEMD/tests/test_emd.py
+++ b/PyEMD/tests/test_emd.py
@@ -203,6 +203,8 @@ class EMDTest(unittest.TestCase):
         all_imfs = emd(S, max_imf=3)
 
         imfs, residue = emd.get_imfs_and_residue()
+
+        assert len(imfs) == 3
         self.assertEqual(all_imfs.shape[0], imfs.shape[0] + 1, "Compare number of components")
         self.assertTrue(np.array_equal(all_imfs[:-1], imfs), "Shouldn't matter where imfs are from")
         self.assertTrue(np.array_equal(all_imfs[-1], residue), "Residue, if any, is the last row")


### PR DESCRIPTION
This PR fixes the condition comparing the `imfNo` to the `max_imf` amount. 

From the documentation, the method is supposed to return `max_imf` amount of IMFs, while currently returning that number +1. 

(Either this change, or an update to the docs would be required. I will leave it to the reviewers to determine which one is more suitable for this.) 