### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ The quickest way to install package is through `pip`.
 
 > \$ pip install EMD-signal
 
-In this way you install the old version of PyEMD hosted on PyPi
+In this way you install the latest stable release of PyEMD hosted on PyPi
 
 ### From source
 
 In case, if you only want to *use* EMD and its variations, the best way to install PyEMD is through `pip`.
-However, if you want to modify the code, anyhow you might want to download the code and build package yourself.
+However, if you want the latest version of PyEMD, anyhow you might want to download the code and build package yourself.
 The source is publicaly available and hosted on [GitHub](https://github.com/laszukdawid/PyEMD).
 To download the code you can either go to the source code page and click `Code -> Download ZIP`, or use **git** command line
 
@@ -78,7 +78,7 @@ A quicker way to install PyEMD from source is done using `pip` and `git` in the 
 >\$ python3 -m pip install git+https://github.com/laszukdawid/PyEMD.git
 
 **Note**, however, that this will install it in your current environment. If you are working on many projects, or sharing reources with others, we suggest using [virtual environments](https://docs.python.org/3/library/venv.html).
-
+If you want to make your installation editable use the `-e` flag for [pip](https://packaging.python.org/en/latest/tutorials/installing-packages/)
 ## Example
 
 More detailed examples are included in the

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The quickest way to install package is through `pip`.
 
 > \$ pip install EMD-signal
 
+In this way you install the old version of PyEMD hosted on PyPi
+
 ### From source
 
 In case, if you only want to *use* EMD and its variations, the best way to install PyEMD is through `pip`.
@@ -67,7 +69,13 @@ To download the code you can either go to the source code page and click `Code -
 
 Installing package from source is done using command line:
 
-> \$ python setup.py install
+> \$ python3 -m pip install .
+
+after entering the PyEM directory created by `git`.
+
+A quicker way to install PyEMD from source is done using `pip` and `git` in the same command:
+
+>\$ python3 -m pip install git+https://github.com/laszukdawid/PyEMD.git
 
 **Note**, however, that this will install it in your current environment. If you are working on many projects, or sharing reources with others, we suggest using [virtual environments](https://docs.python.org/3/library/venv.html).
 

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -50,7 +50,11 @@ In case you like using command line and want a copy-paste line ::
 
 Once the code is downloaded, enter package's directory and execute ::
 
-    $ python setup.py install
+    $ python -m pip install .
+
+Or you can do  it at once with ::
+
+    $ python -m pip install git+https://github.com/laszukdawid/PyEMD.git
 
 This will download all required dependencies and will install PyEMD in your environment.
 Once it's done do a sanity check with quick import and version print: ::


### PR DESCRIPTION
Fixed pip command for installation from source.

The modification is necessary because in the master branch there is no "setup.py" file, making your previous command useless.

Giving to `pip` the path for the package `pip install .`  will install the PyEMD package from the local folder.

The other proposed option skip the explicit download of the repo with git