### PR TITLE
Fix docstring formatting in EEMD and CEEMDAN classes to prevent SyntaxWarning in Python 3.12

### DIFF
--- a/PyEMD/CEEMDAN.py
+++ b/PyEMD/CEEMDAN.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 
 
 class CEEMDAN:
-    """
+    r"""
     **"Complete Ensemble Empirical Mode Decomposition with Adaptive Noise"**
 
     "Complete ensemble empirical mode decomposition with adaptive

--- a/PyEMD/EEMD.py
+++ b/PyEMD/EEMD.py
@@ -22,7 +22,7 @@ from PyEMD.utils import get_timeline
 
 
 class EEMD:
-    """
+    r"""
     **Ensemble Empirical Mode Decomposition**
 
     Ensemble empirical mode decomposition (EEMD) [Wu2009]_


### PR DESCRIPTION
Updates the EEMD and CEEMDAN class docstrings to avoid Python 3.12+ `SyntaxWarning: invalid escape sequence '\h' ` by switching the docstring to a raw string, preserving LaTeX-style backslashes used in the reST :math: directives.