### PR TITLE
perf: solve 3-point cubic spline system directly

### DIFF
--- a/PyEMD/splines.py
+++ b/PyEMD/splines.py
@@ -24,7 +24,7 @@ def cubic_spline_3pts(x, y, T):
 
     M = np.array([[m11, m12, m13], [m21, m22, m23], [m31, m32, m33]])
     v = np.array([v1, v2, v3]).T
-    k = np.linalg.inv(M).dot(v)
+    k = np.linalg.solve(M, v)
 
     a1 = k[0] * x1x0 - y1y0
     b1 = -k[1] * x1x0 + y1y0

--- a/doc/performance_history.rst
+++ b/doc/performance_history.rst
@@ -40,6 +40,19 @@ This benchmark isolates value extraction in ``BEMD.extract_max_min_spline`` by
 stubbing spline construction. If the optional BEMD dependencies are not
 installed, the benchmark is skipped.
 
+The focused 3-point cubic spline benchmark can be run with::
+
+    python perf_test/perf_test_comprehensive.py --test cubic3pts
+
+It executes ``test_cubic_spline_3pts`` with these default parameters:
+
+* ``runs=2000``
+* ``warmup=100``
+* ``timeline_length=512``
+
+This benchmark isolates the small fallback used when cubic spline envelopes have
+only three extrema points.
+
 Saved benchmark runs can be compared with::
 
     python perf_test/compare_results.py <baseline-results> <comparison-results>
@@ -143,3 +156,55 @@ Interpretation
     This is a narrow optimization in an experimental 2D path. It improves the
     value extraction portion of envelope construction, but full BEMD runtime may
     still be dominated by extrema detection and radial-basis interpolation.
+
+Attempt: use solve instead of explicit inverse for 3-point cubic spline
+-----------------------------------------------------------------------
+
+Date evaluated
+    2026-07-11
+
+Area
+    ``PyEMD.splines.cubic_spline_3pts`` coefficient solve.
+
+Motivation
+    The fallback spline for exactly three extrema points computed coefficients
+    with an explicit matrix inverse followed by a dot product::
+
+        np.linalg.inv(M).dot(v)
+
+    Solving the linear system directly avoids constructing the inverse and is
+    the standard NumPy approach for this operation.
+
+Implementation
+    The inverse/dot expression was replaced with::
+
+        np.linalg.solve(M, v)
+
+Correctness result
+    A direct old-vs-new equivalence check over randomized inputs preserved the
+    output timeline exactly and matched spline values within ``1e-12`` absolute
+    and relative tolerance. The full test suite also passed::
+
+        python -m PyEMD.tests.test_all
+        Ran 116 tests
+        OK (skipped=21)
+
+Performance result
+    Comparing the original baseline with the direct-solve implementation showed
+    a statistically significant improvement in the focused benchmark::
+
+        cubic_spline_3pts ({'timeline_length': 512, 'points': 3}):
+        0.0001s -> 0.0001s (-7.3% faster, p=0.000)
+
+    The benchmark reported high variance and the absolute runtime is very
+    small, so the percentage should be treated as directional rather than a
+    precise end-to-end speedup estimate.
+
+Decision
+    The implementation change was kept because it is both faster in the focused
+    benchmark and numerically preferable to explicitly inverting the matrix.
+
+Interpretation
+    This is a small local improvement. It only affects envelope construction
+    cases with exactly three extrema points, so full EMD runtime impact depends
+    on how often a decomposition reaches that fallback path.

--- a/perf_test/perf_test_comprehensive.py
+++ b/perf_test/perf_test_comprehensive.py
@@ -27,6 +27,7 @@ from typing import Callable, Dict, List, Optional
 import numpy as np
 
 from PyEMD import CEEMDAN, EEMD, EMD
+from PyEMD.splines import cubic_spline_3pts
 
 # Results directory
 RESULTS_BASE_DIR = Path(__file__).parent / "results"
@@ -388,6 +389,30 @@ def test_bemd_extrema_value_extraction(
             max=stats.max,
             runs=runs,
             trimmed_mean=stats.trimmed_mean,
+        )
+    ]
+
+
+def test_cubic_spline_3pts(runs: int = 2000, warmup: int = 100) -> List[PerfResult]:
+    """Benchmark the 3-point cubic spline fallback used for sparse extrema."""
+    x = np.array([0.0, 0.37, 1.0])
+    y = np.array([1.0, -0.25, 0.75])
+    T = np.linspace(-0.2, 1.2, 512)
+
+    stats = benchmark(cubic_spline_3pts, x, y, T, runs=runs, warmup=warmup)
+    t, q = cubic_spline_3pts(x, y, T)
+
+    return [
+        PerfResult(
+            name="cubic_spline_3pts",
+            params={"timeline_length": len(T), "points": 3},
+            mean=stats.mean,
+            std=stats.std,
+            min=stats.min,
+            max=stats.max,
+            runs=runs,
+            trimmed_mean=stats.trimmed_mean,
+            extra={"output_length": len(t), "value_checksum": float(np.sum(q))},
         )
     ]
 
@@ -793,8 +818,8 @@ def run_single_test(test_name: str, save: bool = True) -> List[PerfResult]:
     """Run a single test by name.
 
     Args:
-        test_name: One of 'scaling', 'accumulation', 'bemd_values', 'splines',
-                   'extrema', 'eemd', 'ceemdan', 'complexity', 'sifting'
+        test_name: One of 'scaling', 'accumulation', 'bemd_values', 'cubic3pts',
+                   'splines', 'extrema', 'eemd', 'ceemdan', 'complexity', 'sifting'
         save: If True, save results to timestamped directory
 
     Returns:
@@ -809,6 +834,7 @@ def run_single_test(test_name: str, save: bool = True) -> List[PerfResult]:
         "scaling": (test_emd_scaling, "EMD Scaling Test"),
         "accumulation": (test_emd_accumulation, "EMD Accumulation Test"),
         "bemd_values": (test_bemd_extrema_value_extraction, "BEMD Extrema Value Extraction Test"),
+        "cubic3pts": (test_cubic_spline_3pts, "3-point Cubic Spline Test"),
         "splines": (test_spline_methods, "Spline Method Comparison"),
         "extrema": (test_extrema_detection, "Extrema Detection Comparison"),
         "eemd": (test_eemd_parallel, "EEMD Parallel Scaling"),
@@ -844,6 +870,7 @@ Examples:
   python perf_test_comprehensive.py --test scaling     # Single test
   python perf_test_comprehensive.py --test accumulation # EMD accumulation benchmark
   python perf_test_comprehensive.py --test bemd_values # BEMD value extraction benchmark
+  python perf_test_comprehensive.py --test cubic3pts   # 3-point cubic spline benchmark
   python perf_test_comprehensive.py --no-save          # Don't save results
   python perf_test_comprehensive.py --profile --quick  # Profile quick suite
   python perf_test_comprehensive.py --profile --test scaling  # Profile single test
@@ -859,6 +886,7 @@ Results are saved to: perf_test/results/<timestamp>_<prefix>/
             "scaling",
             "accumulation",
             "bemd_values",
+            "cubic3pts",
             "splines",
             "extrema",
             "eemd",


### PR DESCRIPTION
## Summary
- replace explicit matrix inverse with np.linalg.solve in cubic_spline_3pts
- add focused cubic3pts performance benchmark
- document the benchmark result in performance history

## Validation
- old-vs-new randomized equivalence check for cubic_spline_3pts with 1e-12 tolerance
- .venv/bin/python -m PyEMD.tests.test_all
- .venv/bin/python perf_test/perf_test_comprehensive.py --test cubic3pts
- .venv/bin/python perf_test/compare_results.py perf_test/results/20260711_063345_cubic3pts perf_test/results/20260711_063426_cubic3pts
- .venv/bin/sphinx-build -b dummy doc /tmp/opencode/pyemd-doc-dummy

## Benchmark
cubic_spline_3pts: -7.3% faster in the focused benchmark (p=0.000).

Note: the benchmark has high variance and tiny absolute runtime, so this should be treated as a local micro-optimization rather than an end-to-end speedup estimate.