### PR TITLE
Automate package version bumps

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,21 @@
+import re
+import sys
+
+
+def bump_type(commit_message: str) -> str:
+    first_line = commit_message.splitlines()[0].lower()
+
+    if "breaking change" in commit_message.lower() or "!:" in first_line or "!)" in first_line:
+        return "major"
+    if first_line.startswith("feat"):
+        return "minor"
+    return "patch"
+
+
+def main() -> None:
+    commit_message = sys.argv[1]
+    print(bump_type(commit_message))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci-main-build-test-deploy.yml
+++ b/.github/workflows/ci-main-build-test-deploy.yml
@@ -6,6 +6,9 @@ on:
       - master
       - ci-test
 
+permissions:
+  contents: write
+
 jobs:
   build-n-test:
     runs-on: ubuntu-latest
@@ -45,7 +48,7 @@ jobs:
         with:
           filters: |
             pyemd_version:
-              - 'PyEMD/__init__.py'
+              - 'pyproject.toml'
       - name: Check if version is updated
         if: ${{ steps.version.outputs.pyemd_version ==  'true'}}
         run: echo "PyEMD version is updated"
@@ -53,8 +56,42 @@ jobs:
         if: ${{ steps.version.outputs.pyemd_version ==  'false'}}
         run: echo "PyEMD version is not updated"
 
+  bump-version:
+    if: ${{ github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    needs: build-n-test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            code:
+              - 'PyEMD/**/*.py'
+              - 'pyproject.toml'
+              - '!PyEMD/__init__.py'
+      - name: Bump package version
+        id: bump
+        if: ${{ steps.changes.outputs.code == 'true' }}
+        run: |
+          BUMP=$(python .github/scripts/bump_version.py "${{ github.event.head_commit.message }}")
+          echo "bump=$BUMP" >> $GITHUB_OUTPUT
+          uv version --bump "$BUMP"
+      - name: Commit version bump
+        if: ${{ steps.changes.outputs.code == 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump package version"
+          git push
+
   deploy:
-    # Run 'deploy' job only if `PyEMD/__init__.py` is modified
+    # Run 'deploy' job only if the package version is modified
     if: needs.version-updated.outputs.pyemd_version == 'true'
     needs: version-updated
     runs-on: ubuntu-latest
@@ -88,7 +125,7 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          VERSION=$(grep -oP '__version__ = "\K[^"]+' PyEMD/__init__.py)
+          VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/PyEMD/__init__.py
+++ b/PyEMD/__init__.py
@@ -1,6 +1,11 @@
 import logging
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = "1.9.0"
+try:
+    __version__ = version("EMD-signal")
+except PackageNotFoundError:
+    __version__ = "0+unknown"
+
 logger = logging.getLogger("pyemd")
 
 from PyEMD.CEEMDAN import CEEMDAN  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "EMD-signal"
-dynamic = ["version"]
+version = "1.10.0"
 description = "Implementation of the Empirical Mode Decomposition (EMD) and its variations"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -48,9 +48,6 @@ test = [
 [project.urls]
 Homepage = "https://github.com/laszukdawid/PyEMD"
 Repository = "https://github.com/laszukdawid/PyEMD"
-
-[tool.setuptools.dynamic]
-version = { attr = "PyEMD.__version__" }
 
 [tool.setuptools.packages.find]
 include = ["PyEMD*"]


### PR DESCRIPTION
## Summary
- move package version source of truth to pyproject.toml
- use uv version to bump package versions in CI based on commit messages
- deploy and release from pyproject.toml version updates

## Validation
- python -m py_compile .github/scripts/bump_version.py PyEMD/__init__.py
- git diff --check

Note: full tests were not run locally because runtime dependencies such as numpy are not installed in this environment.